### PR TITLE
Add FastAPI skeleton with placeholder dark admin UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+store/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # DevTransfer
-A simple API transfer tool for small or bulk data
+
+A simple API transfer tool for small or bulk data.
+
+This repository contains the foundation for **DevTrans**, including a FastAPI
+server and a placeholder web admin panel styled with Bootstrap's Darkly theme.
+
+## Running the Server
+
+Install the dependencies and start the development server:
+
+```bash
+pip install -r requirements.txt
+uvicorn server.main:app --reload
+```
+
+Visit `http://localhost:8000/admin` and authenticate with the credentials from
+`server.yml` to see the placeholder admin UI.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+python-multipart
+pyyaml
+jinja2

--- a/server.yml
+++ b/server.yml
@@ -1,0 +1,12 @@
+server:
+  base_url: http://localhost:8000
+  storage_dir: ./store
+  expiry_hours: 24
+
+admin_users:
+  - username: admin
+    password: secret
+
+tokens:
+  - name: example
+    token: deadbeefdeadbeefdeadbeefdeadbeef

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,45 @@
+import hashlib
+from fastapi import FastAPI, Depends, File, UploadFile, HTTPException
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from fastapi import Request
+import yaml
+
+app = FastAPI(title="DevTrans Server")
+
+security = HTTPBasic()
+
+CONFIG_PATH = "server.yml"
+
+def load_config():
+    with open(CONFIG_PATH, 'r') as f:
+        return yaml.safe_load(f)
+
+config = load_config()
+
+templates = Jinja2Templates(directory="server/templates")
+
+# Simple in-memory token list loaded from config
+tokens = config.get("tokens", [])
+
+# Basic auth dependency
+async def get_current_admin(credentials: HTTPBasicCredentials = Depends(security)):
+    for user in config.get("admin_users", []):
+        if credentials.username == user.get("username") and credentials.password == user.get("password"):
+            return credentials.username
+    raise HTTPException(status_code=401, detail="Invalid credentials")
+
+@app.put("/upload")
+async def upload_file(file: UploadFile = File(...), token: str = Depends(security)):
+    # Placeholder implementation
+    return {"code": "placeholder"}
+
+@app.get("/download/{code}")
+async def download_file(code: str):
+    # Placeholder implementation
+    raise HTTPException(status_code=404, detail="File not found")
+
+@app.get("/admin", response_class=HTMLResponse)
+async def admin_panel(request: Request, user: str = Depends(get_current_admin)):
+    return templates.TemplateResponse("admin.html", {"request": request, "tokens": tokens})

--- a/server/templates/admin.html
+++ b/server/templates/admin.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Upload Tokens</h1>
+<table class="table table-dark table-striped">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Token</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for token in tokens %}
+    <tr>
+      <td>{{ token.name }}</td>
+      <td>{{ token.token }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title or 'DevTrans Admin' }}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.2.3/dist/darkly/bootstrap.min.css">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/admin">DevTrans Admin</a>
+  </div>
+</nav>
+<div class="container">
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- initialize FastAPI server and load config from `server.yml`
- add placeholder `/upload`, `/download/{code}`, and `/admin` endpoints
- implement dark Bootstrap admin template
- document running instructions in README

## Testing
- `python -m py_compile server/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e3f346ae083338693fac7a77a06e6