### PR TITLE
Add user and admin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ commands:
 export DEVTRANS_TOKEN=deadbeefdeadbeefdeadbeefdeadbeef
 ./devtrans put path/to/file
 ```
+
+## Documentation
+
+Detailed usage instructions are available in the [docs](./docs/) directory:
+
+- [User Guide](docs/UserGuide.md) explains how to build the CLI and transfer files.
+- [Admin Guide](docs/AdminGuide.md) covers running the server and managing tokens.

--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -1,0 +1,38 @@
+# DevTrans Admin Guide
+
+This guide describes how to run the DevTrans server and manage upload tokens.
+
+## Running the Server
+
+Install dependencies from `requirements.txt` and start the FastAPI server:
+
+```bash
+pip install -r requirements.txt
+uvicorn server.main:app --host 0.0.0.0 --reload
+```
+
+The server reads configuration from `server.yml` located in the repository root.
+Adjust `base_url`, `storage_dir` and `expiry_hours` as needed.
+
+## Admin Authentication
+
+Admin credentials are defined under `admin_users` in `server.yml`. The Web Admin Panel uses HTTP Basic authentication.
+
+## Web Admin Panel
+
+Open `http://localhost:8000/admin` in your browser and log in with an admin account.
+
+The panel lists existing upload tokens. You can:
+
+- **Create Token** – enter a name and submit to generate a new token.
+- **Delete Token** – remove a token which immediately invalidates it for future uploads.
+
+## Preloaded Tokens
+
+You can preload tokens by listing them under the `tokens` section of `server.yml`.
+These tokens will be inserted into the database when the server starts.
+
+## Database Location
+
+The server stores metadata in `server.db` (SQLite) in the project root. Remove this file if you need to reset all tokens and uploaded file entries.
+

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,0 +1,49 @@
+# DevTrans User Guide
+
+This guide explains how to transfer files using the DevTrans CLI.
+
+## Prerequisites
+
+- [Go](https://go.dev/) if you need to build the CLI from source.
+- A valid upload token issued by your administrator.
+- Optional: adjust `DEVTRANS_BASE_URL` to point at your DevTrans server.
+
+## Building the CLI
+
+Inside the `cli/` folder run:
+
+```bash
+cd cli
+go build -o devtrans
+```
+
+This produces the `devtrans` binary in the same directory.
+
+## Uploading Files
+
+1. Set the environment variable `DEVTRANS_TOKEN` to the token string provided by your administrator.
+2. Optional: set `DEVTRANS_BASE_URL` if the server is not running on `http://localhost:8000`.
+3. Run:
+
+```bash
+./devtrans put path/to/file
+```
+
+The command returns a file code, a full download URL and an expiry timestamp.
+
+You can also stream the current directory as a ZIP archive using:
+
+```bash
+./devtrans put *
+```
+
+## Downloading Files
+
+To retrieve a file, use the `get` command with the code you received after the upload:
+
+```bash
+./devtrans get CODE
+```
+
+The file is saved under its original filename. One‑time downloads are deleted after the first successful retrieval.
+


### PR DESCRIPTION
## Summary
- add User Guide and Admin Guide in `docs/`
- reference new documentation from README

## Testing
- `go vet ./...`
- `go build -o /tmp/devtrans_test`
- `python -m py_compile server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_685e464114fc83339bdbca145eb4d4f9