### PR TITLE
Add installer scripts for system-wide setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ export DEVTRANS_TOKEN=deadbeefdeadbeefdeadbeefdeadbeef
 ./devtrans put path/to/file
 ```
 
+## System-Wide Setup
+
+The `installer/` directory contains helper scripts for installing the CLI and
+configuring environment variables globally.
+
+- **Linux:** run `sudo installer/linux_install.sh` and follow the prompts.
+- **Windows:** run `PowerShell installer\windows_install.ps1 -Token <token> [-BaseUrl <url>]`.
+
+After installation open a new terminal session and you can invoke `devtrans` from
+any directory.
+
 ## Documentation
 
 Detailed usage instructions are available in the [docs](./docs/) directory:

--- a/installer/linux_install.sh
+++ b/installer/linux_install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Installs DevTrans CLI on Linux and configures system-wide environment variables
+# Requires root privileges.
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run as root" >&2
+    exit 1
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+CLI_DIR="$SCRIPT_DIR/cli"
+
+if ! command -v go >/dev/null 2>&1; then
+    echo "Go is required to build DevTrans" >&2
+    exit 1
+fi
+
+cd "$CLI_DIR"
+echo "Building DevTrans CLI..."
+go build -o /usr/local/bin/devtrans
+
+read -p "Enter your DEVTRANS_TOKEN: " DEVTRANS_TOKEN
+read -p "Enter DEVTRANS_BASE_URL [http://localhost:8000]: " DEVTRANS_BASE_URL
+DEVTRANS_BASE_URL=${DEVTRANS_BASE_URL:-http://localhost:8000}
+
+cat >/etc/profile.d/devtrans.sh <<EOVARS
+export DEVTRANS_TOKEN="${DEVTRANS_TOKEN}"
+export DEVTRANS_BASE_URL="${DEVTRANS_BASE_URL}"
+EOVARS
+
+chmod 644 /etc/profile.d/devtrans.sh
+
+echo "DevTrans installed. Open a new shell to use 'devtrans'."

--- a/installer/windows_install.ps1
+++ b/installer/windows_install.ps1
@@ -1,0 +1,29 @@
+# Installs DevTrans CLI on Windows and configures system-wide environment variables
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Token,
+    [string]$BaseUrl = "http://localhost:8000"
+)
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$rootDir = Join-Path $scriptDir '..'
+$cliDir = Join-Path $rootDir 'cli'
+
+Write-Host 'Building DevTrans CLI...'
+Push-Location $cliDir
+& go build -o devtrans.exe
+Pop-Location
+
+$installDir = "$env:ProgramFiles\DevTrans"
+if (-not (Test-Path $installDir)) { New-Item -ItemType Directory -Path $installDir | Out-Null }
+Copy-Item (Join-Path $cliDir 'devtrans.exe') $installDir -Force
+
+$path = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+if ($path -notlike "*$installDir*") {
+    [Environment]::SetEnvironmentVariable('Path', "$path;$installDir", 'Machine')
+}
+
+[Environment]::SetEnvironmentVariable('DEVTRANS_TOKEN', $Token, 'Machine')
+[Environment]::SetEnvironmentVariable('DEVTRANS_BASE_URL', $BaseUrl, 'Machine')
+
+Write-Host 'DevTrans installed. Restart your command prompt to use devtrans.'


### PR DESCRIPTION
## Summary
- add linux and windows installer scripts under `installer/`
- document how to use these scripts in README

## Testing
- `go build -o /tmp/devtrans`

------
https://chatgpt.com/codex/tasks/task_e_685e4abb013c833384886e01c5110990