### PR TITLE
Add service setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ configuring environment variables globally.
 After installation open a new terminal session and you can invoke `devtrans` from
 any directory.
 
+### Server Install/Update
+
+Use `setup.sh` to deploy the Python server under `/opt/DevTransfer` and run it as a
+systemd service. Execute the script as root:
+
+```bash
+sudo ./setup.sh install    # initial install
+sudo ./setup.sh update     # pull latest code and restart
+```
+
 ## Documentation
 
 Detailed usage instructions are available in the [docs](./docs/) directory:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -e
+
+INSTALL_DIR="/opt/DevTransfer"
+VENVDIR="$INSTALL_DIR/venv"
+SERVICE_FILE="/etc/systemd/system/devtransfer.service"
+
+usage() {
+    echo "Usage: $0 {install|update}" >&2
+    exit 1
+}
+
+install_devtransfer() {
+    if [ "$(id -u)" -ne 0 ]; then
+        echo "Please run as root" >&2
+        exit 1
+    fi
+
+    SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+    echo "Installing DevTransfer to $INSTALL_DIR"
+    if [ -d "$INSTALL_DIR/.git" ]; then
+        echo "Existing git repo detected in $INSTALL_DIR" >&2
+    else
+        if [ -d "$INSTALL_DIR" ]; then
+            echo "Copying files to existing directory" >&2
+        else
+            mkdir -p "$INSTALL_DIR"
+        fi
+        rsync -a --delete --exclude '.git' "$SRC_DIR/" "$INSTALL_DIR/"
+    fi
+
+    if [ ! -d "$VENVDIR" ]; then
+        python3 -m venv "$VENVDIR"
+    fi
+    "$VENVDIR/bin/pip" install --upgrade pip
+    "$VENVDIR/bin/pip" install -r "$INSTALL_DIR/requirements.txt"
+
+    cat > "$SERVICE_FILE" <<EOUNIT
+[Unit]
+Description=DevTransfer Server
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=$INSTALL_DIR
+ExecStart=$VENVDIR/bin/uvicorn server.main:app --host 0.0.0.0
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOUNIT
+
+    systemctl daemon-reload
+    systemctl enable --now devtransfer.service
+    echo "DevTransfer installed and service started"
+}
+
+update_devtransfer() {
+    if [ "$(id -u)" -ne 0 ]; then
+        echo "Please run as root" >&2
+        exit 1
+    fi
+
+    echo "Updating DevTransfer at $INSTALL_DIR"
+    systemctl stop devtransfer.service || true
+    if [ -d "$INSTALL_DIR/.git" ]; then
+        git -C "$INSTALL_DIR" pull
+    else
+        SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
+        rsync -a --delete --exclude '.git' "$SRC_DIR/" "$INSTALL_DIR/"
+    fi
+
+    "$VENVDIR/bin/pip" install -r "$INSTALL_DIR/requirements.txt"
+    systemctl start devtransfer.service
+    echo "Update completed"
+}
+
+case "$1" in
+    install)
+        install_devtransfer
+        ;;
+    update)
+        update_devtransfer
+        ;;
+    *)
+        usage
+        ;;
+esac


### PR DESCRIPTION
## Summary
- create `setup.sh` to install/update the FastAPI server using a venv and systemd
- document how to use the script in README

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68609c636c28833392ee512dd63dbea2