### PR TITLE
Revise admin auth system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ devtrans get 7K9MvX                   # downloads & deletes (oneshot)
 | Create Token | Form field **“Name”** → generates a cryptographically strong random token → instantly adds a row to the table. |
 | Delete Token | “Delete” button removes the token, invalidating future uploads that use it.                                    |
 
-*The panel is served at `/admin`, protected by HTTP Basic Auth with the credentials from the config.*
+*The panel is served at `/admin`. Unauthenticated visitors see a login form. After successful username/password authentication from the config, a session cookie is set.*
 
 ---
 
@@ -95,7 +95,7 @@ admin_users:
 | Web Admin     | FastAPI templating + HTMX/Alpine.js          |
 | Database      | SQLite for metadata & tokens                 |
 | File Store    | Local filesystem                             |
-| Auth (admin)  | HTTP Basic (hashed passwords in config)      |
+| Auth (admin)  | Login form with session cookie (credentials from config) |
 | Auth (upload) | Random 32-byte tokens created in Admin Panel |
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ pip install -r requirements.txt
 uvicorn server.main:app --host 0.0.0.0 --reload
 ```
 
-Visit `http://localhost:8000/admin` and authenticate with the credentials from
-`server.yml`.
+Visit `http://localhost:8000/admin` and log in with the credentials from
+`server.yml` when prompted.
 
 ## Building the CLI
 

--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -16,7 +16,7 @@ Adjust `base_url`, `storage_dir` and `expiry_hours` as needed.
 
 ## Admin Authentication
 
-Admin credentials are defined under `admin_users` in `server.yml`. The Web Admin Panel uses HTTP Basic authentication.
+Admin credentials are defined under `admin_users` in `server.yml`. Unauthenticated visitors to `/admin` are redirected to a login form. After entering a valid username and password they receive a session cookie allowing access to the panel.
 
 ## Web Admin Panel
 

--- a/server/templates/login.html
+++ b/server/templates/login.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Admin Login</h1>
+{% if error %}
+<div class="alert alert-danger">{{ error }}</div>
+{% endif %}
+<form action="/login" method="post" class="w-25">
+  <div class="mb-3">
+    <input type="text" name="username" class="form-control" placeholder="Username" required>
+  </div>
+  <div class="mb-3">
+    <input type="password" name="password" class="form-control" placeholder="Password" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Login</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace HTTP Basic login with form-based session login
- document the new login page in README and AdminGuide
- update AGENTS to describe the login workflow
- add login route and template

## Testing
- `python -m py_compile server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68609dcc6b208333a4e4ed37a7e25171