### PR TITLE
Fix install to copy repo with Git data

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ sudo ./setup.sh install    # initial install
 sudo ./setup.sh update     # pull latest code and restart
 ```
 
+The installation copies the entire repository, including its `.git` directory,
+to `/opt/DevTransfer`. When you later run `sudo ./setup.sh update`, the script
+executes `git pull` inside that directory to fetch updates and restart the
+service.
+
 ## Documentation
 
 Detailed usage instructions are available in the [docs](./docs/) directory:

--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,7 @@ install_devtransfer() {
         else
             mkdir -p "$INSTALL_DIR"
         fi
-        rsync -a --delete --exclude '.git' "$SRC_DIR/" "$INSTALL_DIR/"
+        rsync -a --delete "$SRC_DIR/" "$INSTALL_DIR/"
     fi
 
     if [ ! -d "$VENVDIR" ]; then
@@ -68,7 +68,7 @@ update_devtransfer() {
         git -C "$INSTALL_DIR" pull
     else
         SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
-        rsync -a --delete --exclude '.git' "$SRC_DIR/" "$INSTALL_DIR/"
+        rsync -a --delete "$SRC_DIR/" "$INSTALL_DIR/"
     fi
 
     "$VENVDIR/bin/pip" install -r "$INSTALL_DIR/requirements.txt"


### PR DESCRIPTION
## Summary
- ensure `setup.sh install` copies the `.git` directory
- document that updates now run `git pull` in `/opt/DevTransfer`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860a2ee28a08333a9ab40d710e9c00d