### PR TITLE
Add admin user and file management

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ uvicorn server.main:app --host 0.0.0.0 --reload
 ```
 
 Visit `http://localhost:8000/admin` and log in with the credentials from
-`server.yml` when prompted.
+`server.yml` when prompted. The panel lets you manage upload tokens as well as
+additional admin accounts and existing uploads.
 
 ## Building the CLI
 

--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -27,6 +27,11 @@ The panel lists existing upload tokens. You can:
 - **Create Token** – enter a name and submit to generate a new token.
 - **Delete Token** – remove a token which immediately invalidates it for future uploads.
 
+Additional sections under **Users** and **Files** are available after logging in:
+
+- **Users** – add or remove extra administrator accounts. The first admin configured in `server.yml` remains hard coded.
+- **Files** – review uploaded files, see which token uploaded them and delete entries manually if required.
+
 ## Preloaded Tokens
 
 You can preload tokens by listing them under the `tokens` section of `server.yml`.

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -8,8 +8,16 @@
 </head>
 <body>
 <nav class="navbar navbar-dark bg-dark mb-4">
-  <div class="container-fluid">
+  <div class="container-fluid d-flex justify-content-between">
     <a class="navbar-brand" href="/admin">DevTrans Admin</a>
+    {% if request.session.get('user') %}
+    <div>
+      <a class="btn btn-link text-light" href="/admin">Tokens</a>
+      <a class="btn btn-link text-light" href="/admin/users">Users</a>
+      <a class="btn btn-link text-light" href="/admin/files">Files</a>
+      <a class="btn btn-link text-light" href="/logout">Logout</a>
+    </div>
+    {% endif %}
   </div>
 </nav>
 <div class="container">

--- a/server/templates/files.html
+++ b/server/templates/files.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Uploaded Files</h1>
+<table class="table table-dark table-striped">
+  <thead>
+    <tr>
+      <th>Code</th>
+      <th>Filename</th>
+      <th>Uploaded By</th>
+      <th>Expiry</th>
+      <th>Delete</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for f in files %}
+    <tr>
+      <td>{{ f.code }}</td>
+      <td>{{ f.filename }}</td>
+      <td>{{ f.uploaded_by }}</td>
+      <td>{{ f.expiry }}</td>
+      <td>
+        <form action="/admin/files/delete" method="post" class="d-inline">
+          <input type="hidden" name="code" value="{{ f.code }}">
+          <button class="btn btn-sm btn-danger" type="submit">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/server/templates/users.html
+++ b/server/templates/users.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Admin Users</h1>
+
+<h5>Configured Users</h5>
+<ul>
+  {% for user in static_users %}
+  <li>{{ user.username }}</li>
+  {% endfor %}
+</ul>
+
+<h5 class="mt-4">Additional Users</h5>
+<form action="/admin/users/create" method="post" class="mb-3 d-flex">
+  <input type="text" name="username" class="form-control me-2" placeholder="Username" required>
+  <input type="password" name="password" class="form-control me-2" placeholder="Password" required>
+  <button class="btn btn-primary" type="submit">Create User</button>
+</form>
+<table class="table table-dark table-striped">
+  <thead>
+    <tr>
+      <th>Username</th>
+      <th>Delete</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for user in users %}
+    <tr>
+      <td>{{ user.username }}</td>
+      <td>
+        <form action="/admin/users/delete" method="post" class="d-inline">
+          <input type="hidden" name="username" value="{{ user.username }}">
+          <button class="btn btn-sm btn-danger" type="submit">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- support extra admin users stored in SQLite
- track uploads by token
- add `/admin/users` & `/admin/files` pages
- update navigation menu
- document new features in README and admin guide

## Testing
- `python -m py_compile server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6860a58f739c83339901f50d34666fea