### PR TITLE
Add user dashboard with token login

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 A simple API transfer tool for small or bulk data.
 
 This repository contains the foundation for **DevTrans**, including a FastAPI
-server, a web admin panel and a minimal CLI written in Go.
+server, a web admin panel and a minimal CLI written in Go. A small web
+dashboard is available at the root URL. Users can log in with their API token to
+upload files and review their own uploads.
 
 ## Running the Server
 

--- a/server/templates/dashboard.html
+++ b/server/templates/dashboard.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Your Files</h1>
+<form action="/dashboard/upload" method="post" enctype="multipart/form-data" class="mb-3 d-flex">
+  <input type="file" name="file" class="form-control me-2" required>
+  <button class="btn btn-primary" type="submit">Upload</button>
+</form>
+<table class="table table-dark table-striped">
+  <thead>
+    <tr>
+      <th>Filename</th>
+      <th>Share Link</th>
+      <th>Expiry</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for f in files %}
+    <tr>
+      <td>{{ f.filename }}</td>
+      <td><a href="{{ f.url }}">{{ f.url }}</a></td>
+      <td>{{ f.expiry }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<p><a class="btn btn-secondary" href="/token/logout">Logout</a></p>
+{% endblock %}

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">DevTrans</h1>
+{% if not request.session.get('token') %}
+<form action="/token/login" method="post" class="w-25">
+  <div class="mb-3">
+    <input type="text" name="token" class="form-control" placeholder="API Token" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Login</button>
+</form>
+{% else %}
+<p>You are logged in.</p>
+<p><a class="btn btn-primary" href="/dashboard">Go to Dashboard</a></p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow users to log in using API tokens
- show a dashboard where logged-in users can upload files and see their uploads
- add templates for front page and user dashboard
- mention the dashboard in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6860a80acab88333afcb9e69e255f5c4