### PR TITLE
Display token names in file list

### DIFF
--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -30,7 +30,7 @@ The panel lists existing upload tokens. You can:
 Additional sections under **Users** and **Files** are available after logging in:
 
 - **Users** – add or remove extra administrator accounts. The first admin configured in `server.yml` remains hard coded.
-- **Files** – review uploaded files, see which token uploaded them and delete entries manually if required.
+ - **Files** – review uploaded files, see which token name uploaded them and delete entries manually if required.
 
 ## Preloaded Tokens
 

--- a/server/main.py
+++ b/server/main.py
@@ -303,14 +303,21 @@ async def files_admin(request: Request):
         return RedirectResponse("/login")
     conn = get_db()
     cur = conn.cursor()
-    cur.execute("SELECT code, filename, expiry, uploaded_by, path FROM files")
+    cur.execute(
+        """
+        SELECT files.code, files.filename, files.expiry, files.uploaded_by, files.path,
+               tokens.name AS uploader_name
+        FROM files
+        LEFT JOIN tokens ON files.uploaded_by = tokens.token
+        """
+    )
     rows = cur.fetchall()
     files = [
         {
             "code": r["code"],
             "filename": r["filename"],
             "expiry": datetime.utcfromtimestamp(r["expiry"]).isoformat(),
-            "uploaded_by": r["uploaded_by"],
+            "uploaded_by": r["uploader_name"] or r["uploaded_by"],
         }
         for r in rows
     ]


### PR DESCRIPTION
## Summary
- show token name on /admin/files instead of raw token string
- document the change in the admin guide

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6860aac45ddc83338d016d9b33da4414