### PR TITLE
Add config file support for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,21 @@ go build -o devtrans.exe
 ```
 
 Set `DEVTRANS_TOKEN` and optionally `DEVTRANS_BASE_URL` before running the
-commands. Use `./devtrans` on Linux/macOS or `devtrans.exe` on Windows:
+commands or create `/opt/DevTransClient/config` (Windows: `C:\DevTransClient\config`)
+with the keys `token` and `base_url`. Use `./devtrans` on Linux/macOS or
+`devtrans.exe` on Windows:
 
 ```bash
-export DEVTRANS_TOKEN=deadbeefdeadbeefdeadbeefdeadbeef
 # Linux / macOS
-./devtrans put path/to/file
+DEVTRANS_TOKEN=deadbeefdeadbeefdeadbeefdeadbeef ./devtrans put path/to/file
 # Windows
-devtrans.exe put path\to\file
+$env:DEVTRANS_TOKEN="deadbeefdeadbeefdeadbeefdeadbeef"; devtrans.exe put path\to\file
 ```
 
 ## System-Wide Setup
 
-The `installer/` directory contains helper scripts for installing the CLI and
-configuring environment variables globally.
+The `installer/` directory contains helper scripts for installing the CLI
+system-wide. They also create the configuration file described above.
 
 - **Linux:** run `sudo installer/linux_install.sh` and follow the prompts.
 - **Windows:** run `PowerShell installer\windows_install.ps1 -Token <token> [-BaseUrl <url>]`.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -6,7 +6,9 @@ This guide explains how to transfer files using the DevTrans CLI.
 
 - [Go](https://go.dev/) if you need to build the CLI from source.
 - A valid upload token issued by your administrator.
-- Optional: adjust `DEVTRANS_BASE_URL` to point at your DevTrans server.
+- Optional: adjust the `base_url` in `/opt/DevTransClient/config` (or
+  `C:\DevTransClient\config` on Windows) if the server is not running on
+  `http://localhost:8000`.
 
 ## Building the CLI
 
@@ -24,9 +26,15 @@ This produces the `devtrans` binary in the same directory.
 
 ## Uploading Files
 
-1. Set the environment variable `DEVTRANS_TOKEN` to the token string provided by your administrator.
-2. Optional: set `DEVTRANS_BASE_URL` if the server is not running on `http://localhost:8000`.
-3. Run the upload command. Use `./devtrans` on Linux/macOS or `devtrans.exe` on
+1. Create `/opt/DevTransClient/config` (Windows: `C:\DevTransClient\config`) containing:
+
+   ```
+   token=YOUR_TOKEN
+   base_url=http://localhost:8000
+   ```
+
+   Environment variables `DEVTRANS_TOKEN` and `DEVTRANS_BASE_URL` override these values if set.
+2. Run the upload command. Use `./devtrans` on Linux/macOS or `devtrans.exe` on
    Windows:
 
 ```bash

--- a/installer/linux_install.sh
+++ b/installer/linux_install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Installs DevTrans CLI on Linux and configures system-wide environment variables
+# Installs DevTrans CLI on Linux and writes configuration under /opt/DevTransClient
 # Requires root privileges.
 set -e
 
@@ -24,11 +24,11 @@ read -p "Enter your DEVTRANS_TOKEN: " DEVTRANS_TOKEN
 read -p "Enter DEVTRANS_BASE_URL [http://localhost:8000]: " DEVTRANS_BASE_URL
 DEVTRANS_BASE_URL=${DEVTRANS_BASE_URL:-http://localhost:8000}
 
-cat >/etc/profile.d/devtrans.sh <<EOVARS
-export DEVTRANS_TOKEN="${DEVTRANS_TOKEN}"
-export DEVTRANS_BASE_URL="${DEVTRANS_BASE_URL}"
-EOVARS
+CONFIG_DIR=/opt/DevTransClient
+mkdir -p "$CONFIG_DIR"
+cat >"$CONFIG_DIR/config" <<EOF
+token=${DEVTRANS_TOKEN}
+base_url=${DEVTRANS_BASE_URL}
+EOF
 
-chmod 644 /etc/profile.d/devtrans.sh
-
-echo "DevTrans installed. Open a new shell to use 'devtrans'."
+echo "DevTrans installed. Configuration written to $CONFIG_DIR/config"

--- a/installer/windows_install.ps1
+++ b/installer/windows_install.ps1
@@ -1,4 +1,4 @@
-# Installs DevTrans CLI on Windows and configures system-wide environment variables
+# Installs DevTrans CLI on Windows and writes configuration under C:\DevTransClient
 param(
     [Parameter(Mandatory=$true)]
     [string]$Token,
@@ -23,7 +23,8 @@ if ($path -notlike "*$installDir*") {
     [Environment]::SetEnvironmentVariable('Path', "$path;$installDir", 'Machine')
 }
 
-[Environment]::SetEnvironmentVariable('DEVTRANS_TOKEN', $Token, 'Machine')
-[Environment]::SetEnvironmentVariable('DEVTRANS_BASE_URL', $BaseUrl, 'Machine')
+$cfgDir = 'C:\DevTransClient'
+if (-not (Test-Path $cfgDir)) { New-Item -ItemType Directory -Path $cfgDir | Out-Null }
+"token=$Token`nbase_url=$BaseUrl" | Out-File -Encoding ASCII -FilePath (Join-Path $cfgDir 'config') -Force
 
 Write-Host 'DevTrans installed. Restart your command prompt to use devtrans.'


### PR DESCRIPTION
## Summary
- load settings from `/opt/DevTransClient/config` (or `C:\DevTransClient\config` on Windows)
- update Linux and Windows installer scripts to create config file
- document config usage in README and User Guide

## Testing
- `cd cli && go build && cd ..`
- `bash -n installer/linux_install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6860af00b4a08333baaf4414f55cbdb6