### PR TITLE
Add admin download for files

### DIFF
--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -30,7 +30,7 @@ The panel lists existing upload tokens. You can:
 Additional sections under **Users** and **Files** are available after logging in:
 
 - **Users** – add or remove extra administrator accounts. The first admin configured in `server.yml` remains hard coded.
- - **Files** – review uploaded files, see which token name uploaded them and delete entries manually if required.
+ - **Files** – review uploaded files, see which token name uploaded them, download any file and delete entries manually if required.
 
 ## Preloaded Tokens
 

--- a/server/templates/files.html
+++ b/server/templates/files.html
@@ -8,6 +8,7 @@
       <th>Filename</th>
       <th>Uploaded By</th>
       <th>Expiry</th>
+      <th>Download</th>
       <th>Delete</th>
     </tr>
   </thead>
@@ -18,6 +19,9 @@
       <td>{{ f.filename }}</td>
       <td>{{ f.uploaded_by }}</td>
       <td>{{ f.expiry }}</td>
+      <td>
+        <a class="btn btn-sm btn-primary" href="/admin/files/download/{{ f.code }}">Download</a>
+      </td>
       <td>
         <form action="/admin/files/delete" method="post" class="d-inline">
           <input type="hidden" name="code" value="{{ f.code }}">


### PR DESCRIPTION
## Summary
- allow administrators to download uploaded files
- show download button in `/admin/files`
- document this capability in the Admin Guide

## Testing
- `python -m py_compile server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6860b63ca8a08333a21643d77a94765e