### PR TITLE
Add admin lock on default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ uvicorn server.main:app --host 0.0.0.0 --reload
 ```
 
 Visit `http://localhost:8000/admin` and log in with the credentials from `server.yml` to create upload tokens.
+If the default `admin`/`secret` account or the example token remain in `server.yml`,
+the admin panel is locked and shows a warning until they are changed.
 
 ### 2. Build the CLI
 

--- a/server/templates/warning.html
+++ b/server/templates/warning.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="alert alert-danger text-center">
+  <h2>Change default admin login and token</h2>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- prevent access to the admin panel when default credentials are used
- show a warning message via new template `warning.html`
- note the security check in the README

## Testing
- `python -m py_compile server/main.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6860b8a3c00083338512eb12e3579368