### PR TITLE
Fix session middleware order

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -15,8 +15,6 @@ from fastapi.templating import Jinja2Templates
 import yaml
 
 app = FastAPI(title="DevTrans Server")
-
-app.add_middleware(SessionMiddleware, secret_key="dev-secret")
 bearer_security = HTTPBearer()
 
 CONFIG_PATH = "server.yml"
@@ -64,6 +62,8 @@ async def block_default_admin(request: Request, call_next):
             status_code=403,
         )
     return await call_next(request)
+
+app.add_middleware(SessionMiddleware, secret_key="dev-secret")
 
 
 # Database helpers ----------------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure SessionMiddleware runs before custom auth check

## Testing
- `python3 -m py_compile server/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860b9eca3d08333b73b55d0d5874497