### PR TITLE
Update setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,58 @@ DevTransfer is a small file transfer tool with a FastAPI backend and a simple co
 - Web admin panel to create and revoke tokens
 - Installer scripts for Linux and Windows
 
-## Quick Start
+## Server Setup
 
-1. **Run the Server (optional)**
-   
+Choose one of the following methods to start the FastAPI server.
+
+1. **Manual Install**
+
    ```bash
+   git clone <repository-url>
+   cd DevTransfer
+   python3 -m venv venv
+   source venv/bin/activate
    pip install -r requirements.txt
    uvicorn server.main:app --host 0.0.0.0 --reload
    ```
    Visit `http://localhost:8000/admin` to create an upload token.
 
-2. **Install the CLI**
-   
-   Use the installer for your platform. It builds the binary, places it on your PATH and writes a configuration file with your token.
+2. **setup.sh Script**
+
+   ```bash
+   git clone <repository-url>
+   cd DevTransfer
+   sudo ./setup.sh install
+   ```
+   This installs DevTransfer under `/opt/DevTransfer` with a systemd service.
+
+See [docs/AdminGuide.md](docs/AdminGuide.md) for administration details.
+
+## Client Setup
+
+1. **Manual Build (not recommended)**
+
+   ```bash
+   cd cli
+   go build -o devtrans
+   ```
+
+2. **Installer Scripts**
 
    - Linux: `sudo installer/linux_install.sh`
    - Windows: `installer/windows_install.ps1 -Token <YOUR_TOKEN>`
 
-   Configuration is saved to `/opt/DevTransClient/config` or `C:\DevTransClient\config`.
+   The scripts build the binary, place it on your PATH and write a configuration file with your token. Configuration is saved to `/opt/DevTransClient/config` or `C:\DevTransClient\config`.
 
-3. **Transfer Files**
-   
-   ```bash
-   devtrans put path/to/file
-   devtrans get CODE
-   ```
-   The token and base URL are read from the config file.
+After installation you can transfer files:
+
+```bash
+devtrans put path/to/file
+devtrans get CODE
+```
+
+See [docs/UserGuide.md](docs/UserGuide.md) for usage instructions.
 
 ## Documentation
 
-See the [docs](./docs/) directory for detailed user and admin guides.
+See [docs/UserGuide.md](docs/UserGuide.md) and [docs/AdminGuide.md](docs/AdminGuide.md) for full usage and administration guides.


### PR DESCRIPTION
## Summary
- clarify server setup with virtualenv
- add setup.sh installation option
- separate client setup instructions
- mention user and admin docs explicitly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860bdbacf348333947fe046425876b0