### PR TITLE
Add confirmation page for share links

### DIFF
--- a/server/templates/download.html
+++ b/server/templates/download.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">File Download</h1>
+<p class="mb-3">{{ filename }}</p>
+<a class="btn btn-primary" href="/download/{{ code }}">Open the file</a>
+<p class="mt-3"><small>Link expires at {{ expiry }} or after download.</small></p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create a new `/d/{code}` route that shows a download confirmation
- update share URLs in upload responses and dashboard
- add `download.html` template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860c5e7e320833393bab6dcae95a0c4