### PR TITLE
Add CLI auto-update command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -76,6 +76,17 @@ devtrans get CODE
 
 Files are saved with their original name. One‑time shares are removed after the first successful download.
 
+## Updating the CLI
+
+Check for a newer version with:
+
+```bash
+devtrans --update
+```
+
+The command downloads the latest binary from the server and replaces the current executable.
+After running an upload, the client also notifies you when a new version is available.
+
 ## Web Dashboard
 
 Open the base URL of the DevTrans server in your browser. Enter your token on


### PR DESCRIPTION
## Summary
- enhance the CLI with a `--update` argument
- check server for new version after uploads
- document the update command in the user guide

## Testing
- `go vet ./...`
- `go build` (CLI)
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6860d4bf4dfc8333ac0d5de381e2533a