### PR TITLE
Serve updatable CLI binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The server currently targets **Linux** while the client runs on **Windows and Li
 - Web admin panel to create or revoke tokens and inspect uploads
 - Installer scripts for Linux and Windows
 - Admin interface disabled when the default credentials from `server.yml` are still in use
+- Server hosts the latest CLI binary and supports `devtrans --update`
 
 ## Server Setup
 

--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt
 uvicorn server.main:app --host 0.0.0.0
 ```
 
-Server settings reside in `server.yml` in the project root. Adjust `base_url`, `storage_dir` and `expiry_hours` before deployment.
+Server settings reside in `server.yml` in the project root. Adjust `base_url`, `storage_dir` and `expiry_hours` before deployment. The file also contains a `cli` section specifying the `version` and `binary_path` used for client updates.
 
 ### Systemd Service
 
@@ -25,6 +25,8 @@ For a persistent installation use the `setup.sh` script. It copies the project t
 sudo ./setup.sh install    # install and start devtransfer.service
 sudo ./setup.sh update     # pull updates and restart
 ```
+`setup.sh update` also rebuilds the CLI binary so users can download the latest
+version from `/cli/devtrans`.
 
 ## Accessing the Admin Interface
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -76,8 +76,21 @@ devtrans get CODE
 
 Files are saved with their original name. One‑time shares are removed after the first successful download.
 
+## Updating the CLI
+
+Check for a newer version with:
+
+```bash
+devtrans --update
+```
+
+The command downloads the latest binary from the server and replaces the current executable.
+After running an upload, the client also notifies you when a new version is available.
+You can also fetch the binary manually from `<base_url>/cli/devtrans`.
+
 ## Web Dashboard
 
 Open the base URL of the DevTrans server in your browser. Enter your token on
 the login page to access the dashboard. From there you can upload files through
-the browser and view previously uploaded items.
+the browser and view previously uploaded items. The dashboard also offers a link
+to download the current CLI binary.

--- a/server.yml
+++ b/server.yml
@@ -10,3 +10,7 @@ admin_users:
 tokens:
   - name: example
     token: deadbeefdeadbeefdeadbeefdeadbeef
+
+cli:
+  version: "0.1.0"
+  binary_path: ./cli/devtrans

--- a/server/templates/dashboard.html
+++ b/server/templates/dashboard.html
@@ -5,6 +5,7 @@
   <input type="file" name="file" class="form-control me-2" required>
   <button class="btn btn-primary" type="submit">Upload</button>
 </form>
+<p><a class="btn btn-link" href="/cli/devtrans">Download CLI</a></p>
 <table class="table table-dark table-striped">
   <thead>
     <tr>

--- a/setup.sh
+++ b/setup.sh
@@ -35,6 +35,10 @@ install_devtransfer() {
     fi
     "$VENVDIR/bin/pip" install --upgrade pip
     "$VENVDIR/bin/pip" install -r "$INSTALL_DIR/requirements.txt"
+    if command -v go >/dev/null 2>&1; then
+        echo "Building CLI binary"
+        go build -o "$INSTALL_DIR/cli/devtrans" "$INSTALL_DIR/cli"
+    fi
 
     cat > "$SERVICE_FILE" <<EOUNIT
 [Unit]
@@ -72,6 +76,10 @@ update_devtransfer() {
     fi
 
     "$VENVDIR/bin/pip" install -r "$INSTALL_DIR/requirements.txt"
+    if command -v go >/dev/null 2>&1; then
+        echo "Building CLI binary"
+        go build -o "$INSTALL_DIR/cli/devtrans" "$INSTALL_DIR/cli"
+    fi
     systemctl start devtransfer.service
     echo "Update completed"
 }


### PR DESCRIPTION
## Summary
- add CLI section to `server.yml`
- compile CLI in install/update script
- expose `/cli/version` and `/cli/devtrans` endpoints
- link CLI download from user dashboard
- document the server-hosted CLI in guides

## Testing
- `go vet ./...`
- `go build` (from `cli` dir)
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6860d4bf4dfc8333ac0d5de381e2533a